### PR TITLE
Passing createSNSEvent options

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,22 +96,25 @@ Creates a mock DynamoDB event.
 var utils = require('aws-lambda-test-utils');
 var dynamoEvent = utils.mockEventCreator.createDynamoDBEvent();
 
-```
-
-Default options (which can be overridden):
-```
+// Default options (which can be overridden):
 {
   awsRegion: "eu-west-1",
   eventSourceARN: "arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
   events: [{type: "INSERT", number: 1}]
 };
+
 ```
 
-#### `createSNSEvent()`
+#### `createSNSEvent(options)`
 
 ```js
 var utils = require('aws-lambda-test-utils');
 var dynamoEvent = utils.mockEventCreator.createSNSEvent();
+
+// Default options (which can be overridden):
+{
+  message: "default test message"
+};
 
 ```
 

--- a/mockEvent.js
+++ b/mockEvent.js
@@ -10,7 +10,7 @@ module.exports = {
 }
 
 function createDynamoDBEvent(options){
-  var options = setDefaults(options);
+  var options = setDefaults(options, "dynamo");
   var dynamoEvent = options.events.reduce(function(obj, curr) {
     for (var i = 0; i < curr.number; i++) {
       obj.Records.push(createDynamoDBRecord(curr.type, options));
@@ -50,23 +50,31 @@ function createDynamoDBRecord(type, options) {
   }
 }
 
-function setDefaults(options) {
+function setDefaults(options, type) {
   var defaultOptions = {
-    awsRegion: "eu-west-1",
-    eventSourceARN: "arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
-    events: [{type: "INSERT", number: 1}]
+    dynamo: {
+      awsRegion: "eu-west-1",
+      eventSourceARN: "arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+      events: [{type: "INSERT", number: 1}]
+    },
+    sns: {
+      message: "default test message"
+    }
   };
 
   if (typeof options !== "object") {
-    return defaultOptions;
+    return defaultOptions[type];
   }
-  return Object.keys(defaultOptions).reduce(function(options, curr) {
-    options[curr] = options[curr] ? options[curr] : defaultOptions[curr]
+  return Object.keys(defaultOptions[type]).reduce(function(options, curr) {
+    options[curr] = options[curr] ? options[curr] : defaultOptions[type][curr]
     return options;
   }, options);
 }
 
-function createSNSEvent () {
+function createSNSEvent (options) {
+  var options = setDefaults(options, "sns");
+  options.message = typeof options.message === "string" ? options.message : JSON.stringify(options.message);
+  
   return  {
     "Records": [
       {
@@ -79,7 +87,7 @@ function createSNSEvent () {
           "Signature": "EXAMPLE",
           "SigningCertUrl": "EXAMPLE",
           "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
-          "Message": "Hello from SNS!",
+          "Message": options.message,
           "MessageAttributes": {
             "Test": {
               "Type": "String",

--- a/test/mockEvent.test.js
+++ b/test/mockEvent.test.js
@@ -39,7 +39,34 @@ test('mockEventCreator - createSNSEvent', function(t) {
     var SNSEvent = mockEventCreator.createSNSEvent();
     st.equals(SNSEvent.Records.length, 1, "event should contain 1 Record");
     st.equals(SNSEvent.Records[0].Sns.TopicArn, "arn:aws:sns:EXAMPLE");
-    st.equals(SNSEvent.Records[0].Sns.Message, "Hello from SNS!");
+    st.equals(SNSEvent.Records[0].Sns.Message, "default test message");
+    st.end();
+  });
+  t.end();
+});
+
+test('mockEventCreator - createSNSEvent', function(t) {
+  t.test('options with string message: returns an object with 1 SNS Record, with the custom Message', function(st) {
+    var SNSEvent = mockEventCreator.createSNSEvent({message: "custom message"});
+    st.equals(SNSEvent.Records.length, 1, "event should contain 1 Record");
+    st.equals(SNSEvent.Records[0].Sns.TopicArn, "arn:aws:sns:EXAMPLE");
+    st.equals(SNSEvent.Records[0].Sns.Message, "custom message");
+    st.end();
+  });
+  t.end();
+});
+test('mockEventCreator - createSNSEvent', function(t) {
+  var message = {
+    nested: {
+      object: "test string"
+    }
+  };
+
+  t.test('options with object message: returns an object with 1 SNS Record, with the custom Message', function(st) {
+    var SNSEvent = mockEventCreator.createSNSEvent({message: message});
+    st.equals(SNSEvent.Records.length, 1, "event should contain 1 Record");
+    st.equals(SNSEvent.Records[0].Sns.TopicArn, "arn:aws:sns:EXAMPLE");
+    st.equals(SNSEvent.Records[0].Sns.Message, JSON.stringify(message));
     st.end();
   });
   t.end();


### PR DESCRIPTION
- adds functionality to pass options to createSNSEvent (only option at the moment is for a custom `message`)
- adds tests for functionality
- updates readme for functionality